### PR TITLE
Add endpoints for metric rating retrieval

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/listener/api/exception/NotFoundException.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/listener/api/exception/NotFoundException.java
@@ -16,6 +16,17 @@ public class NotFoundException extends RuntimeException {
         return new NotFoundException(message, status, reason, solution);
     }
 
+    public static NotFoundException metricRatingEntryNotFound(long id) {
+
+        String status = "Not found";
+        String reason = String.format("No metric rating entry found for id '%d'", id);
+        String solution = "Provide an id for an existing metric rating entry";
+
+        String message = getMessageFrom(status, reason, solution);
+
+        return new NotFoundException(message, status, reason, solution);
+    }
+
     private final String status;
     private final String reason;
     private final String solution;

--- a/src/main/java/de/leipzig/htwk/gitrdf/listener/api/model/response/GithubRepositoryOrderMetricRatingResponse.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/listener/api/model/response/GithubRepositoryOrderMetricRatingResponse.java
@@ -1,0 +1,34 @@
+package de.leipzig.htwk.gitrdf.listener.api.model.response;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.GithubRepositoryOrderMetricRatingEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Value
+public class GithubRepositoryOrderMetricRatingResponse {
+
+    public static GithubRepositoryOrderMetricRatingResponse from(GithubRepositoryOrderMetricRatingEntity entity) {
+        return new GithubRepositoryOrderMetricRatingResponse(
+                entity.getId(),
+                entity.getMetricId(),
+                entity.getMetricName(),
+                entity.getRunMetadata(),
+                entity.getCreatedAt(),
+                entity.getTaskSessionId());
+    }
+
+    public static List<GithubRepositoryOrderMetricRatingResponse> toList(List<GithubRepositoryOrderMetricRatingEntity> entities) {
+        return entities.stream().map(GithubRepositoryOrderMetricRatingResponse::from).toList();
+    }
+
+    long id;
+    String metricId;
+    String metricName;
+    String runMetadata;
+    LocalDateTime createdAt;
+    @Schema(description = "Session id of the metric task")
+    String taskSessionId;
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/listener/service/GithubRatingService.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/listener/service/GithubRatingService.java
@@ -1,0 +1,15 @@
+package de.leipzig.htwk.gitrdf.listener.service;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.GithubRepositoryOrderMetricRatingEntity;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+public interface GithubRatingService {
+
+    List<GithubRepositoryOrderMetricRatingEntity> findByGithubRepositoryOrderId(long orderId);
+
+    File getTempRdfFile(long ratingId) throws SQLException, IOException;
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/listener/service/impl/GithubRatingServiceImpl.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/listener/service/impl/GithubRatingServiceImpl.java
@@ -1,0 +1,53 @@
+package de.leipzig.htwk.gitrdf.listener.service.impl;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.GithubRepositoryOrderMetricRatingEntity;
+import de.leipzig.htwk.gitrdf.database.common.repository.GithubRepositoryOrderMetricRatingRepository;
+import de.leipzig.htwk.gitrdf.listener.api.exception.NotFoundException;
+import de.leipzig.htwk.gitrdf.listener.service.GithubRatingService;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.sql.SQLException;
+import java.util.List;
+
+@Service
+public class GithubRatingServiceImpl implements GithubRatingService {
+
+    private final EntityManager entityManager;
+    private final GithubRepositoryOrderMetricRatingRepository ratingRepository;
+
+    public GithubRatingServiceImpl(EntityManager entityManager,
+                                   GithubRepositoryOrderMetricRatingRepository ratingRepository) {
+        this.entityManager = entityManager;
+        this.ratingRepository = ratingRepository;
+    }
+
+    @Override
+    public List<GithubRepositoryOrderMetricRatingEntity> findByGithubRepositoryOrderId(long orderId) {
+        return ratingRepository.findByGithubRepositoryOrderId(orderId);
+    }
+
+    @Override
+    @Transactional
+    public File getTempRdfFile(long ratingId) throws SQLException, IOException {
+        GithubRepositoryOrderMetricRatingEntity entity = entityManager.find(GithubRepositoryOrderMetricRatingEntity.class, ratingId);
+        if (entity == null) {
+            throw NotFoundException.metricRatingEntryNotFound(ratingId);
+        }
+
+        File tempFile = Files.createTempFile("RatingRdf", ".ttl").toFile();
+        try (InputStream in = entity.getRdfBlob().getBinaryStream();
+             OutputStream out = new BufferedOutputStream(new FileOutputStream(tempFile))) {
+            in.transferTo(out);
+        }
+        return tempFile;
+    }
+}


### PR DESCRIPTION
## Summary
- expose API endpoints to list rating metadata and download rating RDFs
- implement `GithubRatingService` with corresponding JPA access
- add response model for metric rating entries
- extend `NotFoundException` with metric rating support

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872e12a1560832b8d9815096e7c0d57